### PR TITLE
SE-3566 Handle user not found when loading staff grading

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -284,6 +284,8 @@ class StaffGradedAssignmentXBlock(XBlock):
                 if not submission:
                     continue
                 user = user_by_anonymous_id(student.student_id)
+                if not user:
+                    continue
                 module, created = StudentModule.objects.get_or_create(
                     course_id=self.course_id,
                     module_state_key=self.location,


### PR DESCRIPTION
This patches the following issue:

```

Traceback (most recent call last):
--
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
response = wrapped_callback(request, *callback_args, **callback_kwargs)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
return func(*args, **kwargs)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/newrelic/hooks/framework_django.py", line 527, in wrapper
return wrapped(*args, **kwargs)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 877, in handle_xblock_callback
return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 982, in _invoke_xblock_handler
resp = instance.handle(handler, req, suffix)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 89, in handle
return self.runtime.handle(self, handler_name, request, suffix)
File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1339, in handle
return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 1029, in handle
results = handler(request, suffix)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 555, in get_staff_grading_data
return Response(json_body=self.staff_grading_data())
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 331, in staff_grading_data
'assignments': list(get_student_data()),
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 293, in get_student_data
'module_type': self.category,
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
return getattr(self.get_queryset(), name)(*args, **kwargs)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 407, in get_or_create
return self._create_object_from_params(lookup, params)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 439, in _create_object_from_params
obj = self.create(**params)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 346, in create
obj = self.model(**kwargs)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 468, in __init__
setattr(self, field.name, rel_obj)
File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/related.py", line 631, in __set__
(instance._meta.object_name, self.field.name)
ValueError: Cannot assign None: "StudentModule.student" does not allow null values.
```

This does not address the cause of invalid student ids getting into the student submissions though.

**Dependencies**: None


**Testing instructions**:

1. install this branch into the edx-platform devstack
1. set up a course with a graded edx-sga block
1. somehow get an invalid student id in a submission (this is the hard part; maybe shell into mysql and edit one?)
1. click the 'grade submissions' as an instructor, and verify that the window opens, you can grade submissions, and existing grades/submissions display


**Reviewers**:

- [ ] @pkulkark
